### PR TITLE
Fix/bug nre in currencies cash get adapter ids

### DIFF
--- a/TLabs.ExchangeSdk/Currencies/CurrenciesCache.cs
+++ b/TLabs.ExchangeSdk/Currencies/CurrenciesCache.cs
@@ -99,7 +99,11 @@ namespace TLabs.ExchangeSdk.Currencies
         public string GetAdapterId(string currencyCode) => GetAdapterIds(currencyCode).FirstOrDefault();
 
         public List<string> GetAdapterIds(string currencyCode) =>
-            GetCurrency(currencyCode).CurrencyAdapters.Select(_ => _.AdapterCode).ToList();
+            GetCurrency(currencyCode)?
+                .CurrencyAdapters?
+                .Select(_ => _.AdapterCode)
+                .ToList()
+            ?? new List<string>();
 
         public int GetBalanceDigits(string currencyCode) => GetCurrency(currencyCode).Digits;
 

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.728</Version>
+    <Version>1.0.729</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
исправлен потенциальный NullReferenceException:
в методе GetAdapterIds сразу лезли в результат от GetCurrency, который потенциально может быть null (т.к. в методе имеется проверка результата на null, но там просто происходит логгирование об этом), если GetCurrency вернул бы null, можно было получить NullReferenceException в методе GetAdapterIds