### PR TITLE
add notificator client api

### DIFF
--- a/TLabs.ExchangeSdk/Notificator/ClientNotificator.cs
+++ b/TLabs.ExchangeSdk/Notificator/ClientNotificator.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Flurl.Http;
+using TLabs.DotnetHelpers;
+
+namespace TLabs.ExchangeSdk.Notificator
+{
+    public class ClientNotificator
+    {
+        /// <summary>
+        /// Sends a template email through Notificator WebAPI.
+        /// The request is persisted in Notificator outbox before delivery.
+        /// </summary>
+        public async Task<EmailDispatchResponse> SendTemplateEmail(
+            string to,
+            string templateName,
+            Dictionary<string, string> arguments = null,
+            string locale = null)
+        {
+            return await SendTemplateEmail(new SendTemplateEmailRequest
+            {
+                To = to,
+                TemplateName = templateName,
+                Locale = locale,
+                Arguments = arguments,
+            });
+        }
+
+        /// <summary>
+        /// Sends a template email through Notificator WebAPI.
+        /// </summary>
+        public async Task<EmailDispatchResponse> SendTemplateEmail(SendTemplateEmailRequest request)
+        {
+            return await "notificator/emails/template"
+                .InternalApi()
+                .PostJsonAsync(request)
+                .ReceiveJson<EmailDispatchResponse>();
+        }
+
+        /// <summary>
+        /// Retries an existing email dispatch request.
+        /// </summary>
+        public async Task<EmailDispatchResponse> RetryTemplateEmail(Guid id, bool processImmediately = true)
+        {
+            return await $"notificator/emails/{id}/retry"
+                .InternalApi()
+                .PostJsonAsync(new RetryEmailRequest { ProcessImmediately = processImmediately })
+                .ReceiveJson<EmailDispatchResponse>();
+        }
+    }
+}

--- a/TLabs.ExchangeSdk/Notificator/EmailDispatchResponse.cs
+++ b/TLabs.ExchangeSdk/Notificator/EmailDispatchResponse.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace TLabs.ExchangeSdk.Notificator
+{
+    public class EmailDispatchResponse
+    {
+        public Guid Id { get; set; }
+
+        public string Status { get; set; }
+
+        public string Error { get; set; }
+    }
+}

--- a/TLabs.ExchangeSdk/Notificator/RetryEmailRequest.cs
+++ b/TLabs.ExchangeSdk/Notificator/RetryEmailRequest.cs
@@ -1,0 +1,7 @@
+namespace TLabs.ExchangeSdk.Notificator
+{
+    public class RetryEmailRequest
+    {
+        public bool ProcessImmediately { get; set; } = true;
+    }
+}

--- a/TLabs.ExchangeSdk/Notificator/SendTemplateEmailRequest.cs
+++ b/TLabs.ExchangeSdk/Notificator/SendTemplateEmailRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace TLabs.ExchangeSdk.Notificator
+{
+    public class SendTemplateEmailRequest
+    {
+        public string To { get; set; }
+
+        public string TemplateName { get; set; }
+
+        public string Locale { get; set; }
+
+        public Dictionary<string, string> Arguments { get; set; }
+    }
+}

--- a/TLabs.ExchangeSdk/ServiceCollectionExtensions.cs
+++ b/TLabs.ExchangeSdk/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ namespace TLabs.ExchangeSdk
             services.AddTransient<P2P.ClientP2P>();
             services.AddTransient<WebApp.ClientWebapp>();
             services.AddTransient<News.ClientNews>();
+            services.AddTransient<Notificator.ClientNotificator>();
 
             services.AddTransient<Farming.ClientFarming>();
             services.AddTransient<Farming.ClientFarmingAdmin>();

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.771</Version>
+    <Version>1.0.772</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- add SDK client methods for Notificator template email sending and retry endpoints
- add request/response DTOs for email dispatch operations
- register `ClientNotificator` in SDK service collection extensions

## Test plan
- Verified branch diff against `master`
- Not run: SDK build in this commit step