### PR TITLE
feat(staking): USDT/TRX accrual schedule (Daily / AtMaturity)

### DIFF
--- a/TLabs.ExchangeSdk/Staking/StakingAccrualSchedule.cs
+++ b/TLabs.ExchangeSdk/Staking/StakingAccrualSchedule.cs
@@ -1,0 +1,18 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace TLabs.ExchangeSdk.Staking
+{
+    /// <summary>
+    /// How staking rewards are accrued for a setting / stake.
+    /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum StakingAccrualSchedule
+    {
+        /// <summary>One accrual slot per calendar day (legacy behaviour).</summary>
+        Daily = 0,
+
+        /// <summary>Single payout at end of lock (principal * APR * days / 365).</summary>
+        AtMaturity = 1,
+    }
+}

--- a/TLabs.ExchangeSdk/Staking/StakingSetting.cs
+++ b/TLabs.ExchangeSdk/Staking/StakingSetting.cs
@@ -26,6 +26,9 @@ namespace TLabs.ExchangeSdk.Staking
 
         public int LockPeriodDays { get; set; }
 
+        /// <summary>Daily accrual slots vs single payout at maturity.</summary>
+        public StakingAccrualSchedule AccrualSchedule { get; set; } = StakingAccrualSchedule.Daily;
+
         public bool NotificationNeeded { get; set; }
 
         /// <summary>How much will go to AccountChart UserBonuses</summary>

--- a/TLabs.ExchangeSdk/Staking/UserStake.cs
+++ b/TLabs.ExchangeSdk/Staking/UserStake.cs
@@ -30,6 +30,9 @@ namespace TLabs.ExchangeSdk.Staking
 
         public decimal SingleAccrualAmount { get; set; }
 
+        /// <summary>Snapshot of <see cref="StakingSetting.AccrualSchedule"/> at stake creation.</summary>
+        public StakingAccrualSchedule AccrualSchedule { get; set; } = StakingAccrualSchedule.Daily;
+
         /// <summary>Daily accrual in USDT (fixed at stake open).</summary>
         public decimal? SingleAccrualAmountUsdt { get; set; }
 

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.792</Version>
+    <Version>1.0.793</Version>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RabbitMQ.Client" Version="5.1.0" />
     <PackageReference Include="TLabs.DotnetHelpers" Version="1.0.70" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Adds `StakingAccrualSchedule` (`Daily` / `AtMaturity`) for staking products such as fixed-term USDT/TRX plans where rewards accrue at maturity.

## Changes

- New enum `StakingAccrualSchedule` with JSON string serialization (`StringEnumConverter`)
- `AccrualSchedule` on `StakingSetting` and `UserStake`
- Package **1.0.793**; `Newtonsoft.Json` reference for enum serialization

## Consumers

Brokerage / admin should consume this version and map DB columns to the new fields.

Made with [Cursor](https://cursor.com)