### PR TITLE
feat(helpdesk): Telegram support-bot SDK models and client

### DIFF
--- a/TLabs.ExchangeSdk/Helpdesk/AddTicketMessageDto.cs
+++ b/TLabs.ExchangeSdk/Helpdesk/AddTicketMessageDto.cs
@@ -9,5 +9,6 @@ namespace TLabs.ExchangeSdk.Helpdesk
         public bool isAdminReply { get; set; }
         public string Message { get; set; }
         public List<Guid> FileIds { get; set; }
+        public List<TelegramAttachmentDto> TelegramAttachments { get; set; } = new List<TelegramAttachmentDto>();
     }
 }

--- a/TLabs.ExchangeSdk/Helpdesk/ClientHelpdesk.cs
+++ b/TLabs.ExchangeSdk/Helpdesk/ClientHelpdesk.cs
@@ -63,6 +63,24 @@ namespace TLabs.ExchangeSdk.Helpdesk
                 .PostJsonAsync(null);
         }
 
+        public async Task<HelpdeskTicket> GetTicketByExternalRequestId(string externalRequestId)
+        {
+            return await $"helpdesk/helpdesk/by-external/{externalRequestId}".InternalApi()
+                .GetJsonAsync<HelpdeskTicket>();
+        }
+
+        public async Task<TelegramTicketResponseDto> CreateTelegramTicket(TelegramTicketCreateDto model)
+        {
+            return await $"helpdesk/helpdesk/telegram/tickets".InternalApi()
+                .PostJsonAsync<TelegramTicketResponseDto>(model);
+        }
+
+        public async Task<TelegramTicketResponseDto> AddTelegramMessage(string externalRequestId, TelegramTicketMessageCreateDto model)
+        {
+            return await $"helpdesk/helpdesk/telegram/tickets/{externalRequestId}/messages".InternalApi()
+                .PostJsonAsync<TelegramTicketResponseDto>(model);
+        }
+
         public async Task<string> Healthcheck() =>
             await $"helpdesk/healthcheck".InternalApi().GetStringAsync();
     }

--- a/TLabs.ExchangeSdk/Helpdesk/File.cs
+++ b/TLabs.ExchangeSdk/Helpdesk/File.cs
@@ -1,4 +1,5 @@
 using System;
+using TLabs.DotnetHelpers;
 
 namespace TLabs.ExchangeSdk.Helpdesk;
 
@@ -9,4 +10,8 @@ public class File
     public byte[] Data { get; set; }
     public Guid? MessageId { get; set; }
     public HelpdeskTicketMessage Message { get; set; }
+    public string TelegramFileId { get; set; }
+    public string TelegramFileUniqueId { get; set; }
+
+    public bool IsTelegramAttachment => TelegramFileId.HasValue();
 }

--- a/TLabs.ExchangeSdk/Helpdesk/HelpdeskTicket.cs
+++ b/TLabs.ExchangeSdk/Helpdesk/HelpdeskTicket.cs
@@ -42,6 +42,15 @@ namespace TLabs.ExchangeSdk.Helpdesk
         /// </summary>
         public string UserId { get; set; }
 
+        /// <summary>Bot-side stable request id (unique when set)</summary>
+        public string ExternalRequestId { get; set; }
+
+        /// <summary>Telegram user id for bot-originated tickets</summary>
+        public long? TelegramUserId { get; set; }
+
+        /// <summary>Ticket source, e.g. telegram</summary>
+        public string Source { get; set; }
+
         /// <summary>
         /// Last Message
         /// </summary>

--- a/TLabs.ExchangeSdk/Helpdesk/TelegramSupportDtos.cs
+++ b/TLabs.ExchangeSdk/Helpdesk/TelegramSupportDtos.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace TLabs.ExchangeSdk.Helpdesk;
+
+public class TelegramAttachmentDto
+{
+    public string TelegramFileId { get; set; }
+    public string TelegramFileUniqueId { get; set; }
+}
+
+public class TelegramTicketCreateDto
+{
+    public string ExternalRequestId { get; set; }
+    public long TelegramUserId { get; set; }
+    public string Source { get; set; }
+    public string Text { get; set; }
+    public string Header { get; set; }
+    public List<TelegramAttachmentDto> Attachments { get; set; } = new List<TelegramAttachmentDto>();
+}
+
+public class TelegramTicketMessageCreateDto
+{
+    public string Text { get; set; }
+    public List<TelegramAttachmentDto> Attachments { get; set; } = new List<TelegramAttachmentDto>();
+}
+
+public class TelegramTicketResponseDto
+{
+    public Guid TicketId { get; set; }
+    public string RequestId { get; set; }
+    public int Number { get; set; }
+    public long TelegramUserId { get; set; }
+    public string ExternalRequestId { get; set; }
+    public bool Created { get; set; }
+}
+
+public class SupportBotReplyDto
+{
+    public long TelegramUserId { get; set; }
+    public string RequestId { get; set; }
+    public string Text { get; set; }
+}

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.843</Version>
+    <Version>1.0.844</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Extend `HelpdeskTicket` and `File` with Telegram/external-request metadata for support-bot integration.
- Add Telegram DTOs (`TelegramTicketCreateDto`, `TelegramTicketMessageCreateDto`, `TelegramTicketResponseDto`, `SupportBotReplyDto`, `TelegramAttachmentDto`).
- Add `ClientHelpdesk` methods: `GetTicketByExternalRequestId`, `CreateTelegramTicket`, `AddTelegramMessage`.
- Allow Telegram attachments on `AddTicketMessageDto`.
- Bump package version to `1.0.844`.

## Test plan
- [ ] `dotnet build` in `exchange-sdk`
- [ ] After NuGet publish, verify consuming services (`stock-helpdesk`, `stock-n10-webapp`) compile against `1.0.844`


Made with [Cursor](https://cursor.com)