### PR TITLE
Add Telegram id mapping support for ApplicationUser

### DIFF
--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.853</Version>
+    <Version>1.0.854</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/TLabs.ExchangeSdk/Users/ApplicationUser.cs
+++ b/TLabs.ExchangeSdk/Users/ApplicationUser.cs
@@ -45,6 +45,9 @@ namespace TLabs.ExchangeSdk.Users
 
         public string TelegramLogin { get; set; }
 
+        /// <summary>Telegram numeric user id, bound via Telegram Mini App initData validation. Distinct from <see cref="TelegramLogin"/> (username).</summary>
+        public long? TelegramId { get; set; }
+
         /// <summary>True if user currently has VIP status (balance condition met or grace active)</summary>
         public bool IsVip { get; set; }
 

--- a/TLabs.ExchangeSdk/Users/ClientUsers.cs
+++ b/TLabs.ExchangeSdk/Users/ClientUsers.cs
@@ -476,5 +476,46 @@ namespace TLabs.ExchangeSdk.Users
             return result;
         }
 
+        /// <summary>Binds a Telegram numeric user id (from HMAC-validated initData) to a binibit userId.</summary>
+        public async Task<QueryResult> SetTelegramId(string userId, long telegramId)
+        {
+            return await $"userprofiles/users/{userId}/telegram-id".InternalApi()
+                .PutJsonAsync(telegramId)
+                .GetQueryResult();
+        }
+
+        /// <summary>Looks up an already-bound userId by Telegram numeric user id, null if not bound yet.</summary>
+        public async Task<string> GetUserIdByTelegramId(long telegramId)
+        {
+            try
+            {
+                return await $"userprofiles/users/by-telegram-id/{telegramId}".InternalApi()
+                    .GetJsonAsync<string>();
+            }
+            catch (FlurlHttpException ex) when (ex.Call.HttpResponseMessage?.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates a short-lived one-time token that proves ownership of <paramref name="userId"/>,
+        /// to be handed to Telegram (via a deeplink) so the Mini App can later bind its telegramId to this user.
+        /// </summary>
+        public async Task<TelegramLinkTokenDto> CreateTelegramLinkToken(string userId)
+        {
+            return await $"userprofiles/users/{userId}/telegram-link-token".InternalApi()
+                .PostJsonAsync(null)
+                .ReceiveJson<TelegramLinkTokenDto>();
+        }
+
+        /// <summary>Consumes a link token created above and binds telegramId to the user that created it.</summary>
+        public async Task<QueryResult> ConsumeTelegramLinkToken(string token, long telegramId)
+        {
+            return await $"userprofiles/users/telegram-link-token/{token}/consume".InternalApi()
+                .PostJsonAsync(new { telegramId })
+                .GetQueryResult();
+        }
+
     }
 }

--- a/TLabs.ExchangeSdk/Users/TelegramLinkTokenDto.cs
+++ b/TLabs.ExchangeSdk/Users/TelegramLinkTokenDto.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace TLabs.ExchangeSdk.Users;
+
+public class TelegramLinkTokenDto
+{
+    public string Token { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+}


### PR DESCRIPTION
## Summary
- Adds nullable `TelegramId` (numeric Telegram user id) to `ApplicationUser`, distinct from the existing `TelegramLogin` (username) field.
- Adds `ClientUsers` methods so downstream services (webapp, identity) can bind/lookup a binibit account by Telegram id and manage one-time account-linking tokens:
  - `SetTelegramId(userId, telegramId)`
  - `GetUserIdByTelegramId(telegramId)`
  - `CreateTelegramLinkToken(userId)` / `ConsumeTelegramLinkToken(token, telegramId)`

## Why
Needed to connect the Telegram Mini App to binibit.com: map `telegram_id` <-> binibit `userId` so referral binds land in the same affiliate graph (R0-R8) whether a user signs up on the website or via the Mini App, and so an existing website user can link their Telegram account via a deeplink.

Consumers already implemented against this SDK surface, pending a package version bump once this is merged:
- `stock-userprofiles` - stores `TelegramId`, exposes internal bind/lookup/link-token endpoints.
- `stock-n10-webapp` - public BFF endpoints (`api/users/my/telegram-id`, `api/users/my/telegram-link`, `api/telegram/link/confirm`).
- `stock-n10-identity` - new `telegram` IdentityServer4 extension grant for Mini App login/registration with referral binding.

## Test plan
- [x] `dotnet build` on `TLabs.ExchangeSdk` passes.
- [ ] After merge: bump `TLabs.ExchangeSdk` package version and update the reference in `stock-n10-webapp` and `stock-n10-identity` so they pick up `ClientUsers.SetTelegramId`/`GetUserIdByTelegramId`/`CreateTelegramLinkToken`/`ConsumeTelegramLinkToken`.
