### PR TITLE
Extract Telegram methods into dedicated ClientTelegram

### DIFF
--- a/TLabs.ExchangeSdk/ServiceCollectionExtensions.cs
+++ b/TLabs.ExchangeSdk/ServiceCollectionExtensions.cs
@@ -49,6 +49,7 @@ namespace TLabs.ExchangeSdk
 
             services.AddTransient<Users.ClientUsers>();
             services.AddTransient<Users.ClientFavoritePairs>();
+            services.AddTransient<Users.ClientTelegram>();
             services.AddTransient<Users.IIPService, Users.IPService>();
             services.AddTransient<Verification.ClientVerifications>();
 

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.854</Version>
+    <Version>1.0.855</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/TLabs.ExchangeSdk/Users/ClientTelegram.cs
+++ b/TLabs.ExchangeSdk/Users/ClientTelegram.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Threading.Tasks;
+using Flurl.Http;
+using TLabs.DotnetHelpers;
+
+namespace TLabs.ExchangeSdk.Users
+{
+    /// <summary>
+    /// Binds/looks up the mapping between a Telegram numeric user id and a binibit userId
+    /// (used to connect the Telegram Mini App to binibit.com - see TelegramGrantValidator in
+    /// stock-n10-identity and ApiTelegramLinkController in stock-n10-webapp).
+    /// </summary>
+    public class ClientTelegram
+    {
+        public ClientTelegram()
+        {
+        }
+
+        /// <summary>Binds a Telegram numeric user id (from HMAC-validated initData) to a binibit userId.</summary>
+        public virtual async Task<QueryResult> SetTelegramId(string userId, long telegramId)
+        {
+            return await $"userprofiles/users/{userId}/telegram-id".InternalApi()
+                .PutJsonAsync(telegramId)
+                .GetQueryResult();
+        }
+
+        /// <summary>Looks up an already-bound userId by Telegram numeric user id, null if not bound yet.</summary>
+        public virtual async Task<string> GetUserIdByTelegramId(long telegramId)
+        {
+            try
+            {
+                return await $"userprofiles/users/by-telegram-id/{telegramId}".InternalApi()
+                    .GetJsonAsync<string>();
+            }
+            catch (FlurlHttpException ex) when (ex.Call.HttpResponseMessage?.StatusCode == HttpStatusCode.NotFound)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Creates a short-lived one-time token that proves ownership of <paramref name="userId"/>,
+        /// to be handed to Telegram (via a deeplink) so the Mini App can later bind its telegramId to this user.
+        /// </summary>
+        public virtual async Task<TelegramLinkTokenDto> CreateTelegramLinkToken(string userId)
+        {
+            return await $"userprofiles/users/{userId}/telegram-link-token".InternalApi()
+                .PostJsonAsync(null)
+                .ReceiveJson<TelegramLinkTokenDto>();
+        }
+
+        /// <summary>Consumes a link token created above and binds telegramId to the user that created it.</summary>
+        public virtual async Task<QueryResult> ConsumeTelegramLinkToken(string token, long telegramId)
+        {
+            return await $"userprofiles/users/telegram-link-token/{token}/consume".InternalApi()
+                .PostJsonAsync(new { telegramId })
+                .GetQueryResult();
+        }
+    }
+}

--- a/TLabs.ExchangeSdk/Users/ClientUsers.cs
+++ b/TLabs.ExchangeSdk/Users/ClientUsers.cs
@@ -476,46 +476,5 @@ namespace TLabs.ExchangeSdk.Users
             return result;
         }
 
-        /// <summary>Binds a Telegram numeric user id (from HMAC-validated initData) to a binibit userId.</summary>
-        public async Task<QueryResult> SetTelegramId(string userId, long telegramId)
-        {
-            return await $"userprofiles/users/{userId}/telegram-id".InternalApi()
-                .PutJsonAsync(telegramId)
-                .GetQueryResult();
-        }
-
-        /// <summary>Looks up an already-bound userId by Telegram numeric user id, null if not bound yet.</summary>
-        public async Task<string> GetUserIdByTelegramId(long telegramId)
-        {
-            try
-            {
-                return await $"userprofiles/users/by-telegram-id/{telegramId}".InternalApi()
-                    .GetJsonAsync<string>();
-            }
-            catch (FlurlHttpException ex) when (ex.Call.HttpResponseMessage?.StatusCode == HttpStatusCode.NotFound)
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Creates a short-lived one-time token that proves ownership of <paramref name="userId"/>,
-        /// to be handed to Telegram (via a deeplink) so the Mini App can later bind its telegramId to this user.
-        /// </summary>
-        public async Task<TelegramLinkTokenDto> CreateTelegramLinkToken(string userId)
-        {
-            return await $"userprofiles/users/{userId}/telegram-link-token".InternalApi()
-                .PostJsonAsync(null)
-                .ReceiveJson<TelegramLinkTokenDto>();
-        }
-
-        /// <summary>Consumes a link token created above and binds telegramId to the user that created it.</summary>
-        public async Task<QueryResult> ConsumeTelegramLinkToken(string token, long telegramId)
-        {
-            return await $"userprofiles/users/telegram-link-token/{token}/consume".InternalApi()
-                .PostJsonAsync(new { telegramId })
-                .GetQueryResult();
-        }
-
     }
 }


### PR DESCRIPTION
## Summary
- Extracted the four Telegram id mapping methods (`SetTelegramId`, `GetUserIdByTelegramId`, `CreateTelegramLinkToken`, `ConsumeTelegramLinkToken`) out of `ClientUsers` into a new dedicated `ClientTelegram` client, registered for DI in `ServiceCollectionExtensions`.
- Bumped package version to `1.0.855`.

## Test plan
- `dotnet build` passes locally.
