### PR TITLE
Add BINI transfer recipients report client (1.0.867)

### DIFF
--- a/TLabs.ExchangeSdk/Staking/BiniTransferRecipientsReportDtos.cs
+++ b/TLabs.ExchangeSdk/Staking/BiniTransferRecipientsReportDtos.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace TLabs.ExchangeSdk.Staking;
+
+public class BiniTransferRecipientsReportDto
+{
+    public string SenderUserId { get; set; }
+    public string SenderEmail { get; set; }
+    public List<BiniTransferRecipientRowDto> Recipients { get; set; } = new();
+}
+
+public class BiniTransferRecipientRowDto
+{
+    public string UserId { get; set; }
+    public string Email { get; set; }
+    public decimal ReceivedAmount { get; set; }
+    public DateTimeOffset? FirstReceivedAt { get; set; }
+
+    public bool NoYearlyStaking { get; set; }
+    public decimal ActiveAnnualStakedAmount { get; set; }
+    public decimal AnnualStakeShortfall { get; set; }
+
+    public SoldSpotDto SpotSell { get; set; } = new();
+    public SoldExternalDto ExternalWithdrawal { get; set; } = new();
+    public SoldInternalDto OnwardInternalTransfer { get; set; } = new();
+    public SoldBalanceDto BalanceHeuristic { get; set; } = new();
+}
+
+public class SoldCounterpartyDto
+{
+    public string IdOrAddress { get; set; }
+    public string Label { get; set; }
+    public decimal Amount { get; set; }
+}
+
+public class SoldSpotDto
+{
+    public bool Flag { get; set; }
+    public decimal AmountSold { get; set; }
+    public List<SoldCounterpartyDto> Counterparties { get; set; } = new();
+}
+
+public class SoldExternalDto
+{
+    public bool Flag { get; set; }
+    public decimal Amount { get; set; }
+    public List<SoldCounterpartyDto> Counterparties { get; set; } = new();
+}
+
+public class SoldInternalDto
+{
+    public bool Flag { get; set; }
+    public decimal Amount { get; set; }
+    public List<SoldCounterpartyDto> Counterparties { get; set; } = new();
+}
+
+public class SoldBalanceDto
+{
+    public bool Flag { get; set; }
+    public decimal AvailableBalance { get; set; }
+    public decimal Shortfall { get; set; }
+}

--- a/TLabs.ExchangeSdk/Staking/ClientStaking.cs
+++ b/TLabs.ExchangeSdk/Staking/ClientStaking.cs
@@ -38,6 +38,8 @@ namespace TLabs.ExchangeSdk.Staking
 
         Task<QueryResult> AdminCancelUserStake(Guid userStakeId);
 
+        Task<BiniTransferRecipientsReportDto> GetBiniTransferRecipientsReport(string senderUserId);
+
         Task<StakingStatisticsDto> GetStakingStatistics(IReadOnlyCollection<string> userIds = null);
 
         Task<int> GetStakesCountForPeriod(DateTimeOffset fromDate, DateTimeOffset toDate,
@@ -160,6 +162,14 @@ namespace TLabs.ExchangeSdk.Staking
             if (!result.Succeeded)
                 _logger.LogError($"AdminCancelUserStake failed for {userStakeId}: {result.ErrorsString}");
             return result;
+        }
+
+        public async Task<BiniTransferRecipientsReportDto> GetBiniTransferRecipientsReport(string senderUserId)
+        {
+            return await $"brokerage/staking/admin/bini-transfer-recipients/{senderUserId}/report"
+                .InternalApi()
+                .WithTimeout(TimeSpan.FromMinutes(10))
+                .GetJsonAsync<BiniTransferRecipientsReportDto>();
         }
 
         public virtual async Task<StakingStatisticsDto> GetStakingStatistics(IReadOnlyCollection<string> userIds = null)

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.866</Version>
+    <Version>1.0.867</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

- Bumps `TLabs.ExchangeSdk` to **1.0.867**
- Adds report DTOs for the admin BINI transfer recipients report
- Adds `IClientStaking.GetBiniTransferRecipientsReport` → `GET brokerage/staking/admin/bini-transfer-recipients/{senderUserId}/report`

Plan: `.cursor/workflow/admin-token-recipients/plan.md` (workspace `cryptoWork`)

## Release prerequisite

**Publish this package to nuget.org before consumer CI can restore:**

```bat
dotnet pack TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj -c Release -o ..\.nuget-local
dotnet nuget push ..\.nuget-local\TLabs.ExchangeSdk.1.0.867.nupkg --source https://api.nuget.org/v3/index.json --api-key %NUGET_API_KEY%
```

Local nupkg (if already packed): `c:\cryptoWork\.nuget-local\TLabs.ExchangeSdk.1.0.867.nupkg`

Without publish, consumers fail restore with `NU1102` (nearest public is 1.0.866).

## Related PRs

- stock-brokerage: https://github.com/ateregulov/stock-brokerage/pull/75
- stock-admin: https://github.com/ateregulov/stock-admin/pull/299

Preferred merge order: **this SDK PR first** → publish 1.0.867 → brokerage + admin.

## Test plan

- [ ] Pack succeeds at 1.0.867
- [ ] Push to nuget.org with `NUGET_API_KEY`
- [ ] Confirm `https://api.nuget.org/v3-flatcontainer/tlabs.exchangesdk/index.json` lists 1.0.867