### PR TITLE
Staking totals-by-lock client + SoldChannelDto

### DIFF
--- a/TLabs.ExchangeSdk/Staking/BiniTransferRecipientsReportDtos.cs
+++ b/TLabs.ExchangeSdk/Staking/BiniTransferRecipientsReportDtos.cs
@@ -21,9 +21,9 @@ public class BiniTransferRecipientRowDto
     public decimal ActiveAnnualStakedAmount { get; set; }
     public decimal AnnualStakeShortfall { get; set; }
 
-    public SoldSpotDto SpotSell { get; set; } = new();
-    public SoldExternalDto ExternalWithdrawal { get; set; } = new();
-    public SoldInternalDto OnwardInternalTransfer { get; set; } = new();
+    public SoldChannelDto SpotSell { get; set; } = new();
+    public SoldChannelDto ExternalWithdrawal { get; set; } = new();
+    public SoldChannelDto OnwardInternalTransfer { get; set; } = new();
     public SoldBalanceDto BalanceHeuristic { get; set; } = new();
 }
 
@@ -34,21 +34,7 @@ public class SoldCounterpartyDto
     public decimal Amount { get; set; }
 }
 
-public class SoldSpotDto
-{
-    public bool Flag { get; set; }
-    public decimal AmountSold { get; set; }
-    public List<SoldCounterpartyDto> Counterparties { get; set; } = new();
-}
-
-public class SoldExternalDto
-{
-    public bool Flag { get; set; }
-    public decimal Amount { get; set; }
-    public List<SoldCounterpartyDto> Counterparties { get; set; } = new();
-}
-
-public class SoldInternalDto
+public class SoldChannelDto
 {
     public bool Flag { get; set; }
     public decimal Amount { get; set; }

--- a/TLabs.ExchangeSdk/Staking/ClientStaking.cs
+++ b/TLabs.ExchangeSdk/Staking/ClientStaking.cs
@@ -34,6 +34,9 @@ namespace TLabs.ExchangeSdk.Staking
 
         Task<Dictionary<string, decimal>> GetUsersStakesTotal(GetUserStakesTotalRequest request);
 
+        Task<Dictionary<string, UserStakesTotalsByLockDto>> GetUsersStakesTotalsByLock(
+            GetUserStakesTotalsByLockRequest request);
+
         Task<List<UserStake>> GetAllUserStakes(UserStakingStatus? status = null);
 
         Task<QueryResult> AdminCancelUserStake(Guid userStakeId);
@@ -145,6 +148,16 @@ namespace TLabs.ExchangeSdk.Staking
             var result = await $"brokerage/staking/user-stakes/total".InternalApi()
                 .PostJsonAsync<Dictionary<string, decimal>>(request).GetQueryResult();
             return result.Succeeded ? result.Data : new Dictionary<string, decimal>();
+        }
+
+        public virtual async Task<Dictionary<string, UserStakesTotalsByLockDto>> GetUsersStakesTotalsByLock(
+            GetUserStakesTotalsByLockRequest request)
+        {
+            var result = await $"brokerage/staking/admin/user-stakes/totals-by-lock".InternalApi()
+                .PostJsonAsync<Dictionary<string, UserStakesTotalsByLockDto>>(request).GetQueryResult();
+            return result.Succeeded
+                ? result.Data
+                : new Dictionary<string, UserStakesTotalsByLockDto>();
         }
 
         public async Task<List<UserStake>> GetAllUserStakes(UserStakingStatus? status = null)

--- a/TLabs.ExchangeSdk/Staking/GetUserStakesTotalsByLockRequest.cs
+++ b/TLabs.ExchangeSdk/Staking/GetUserStakesTotalsByLockRequest.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace TLabs.ExchangeSdk.Staking;
+
+public class GetUserStakesTotalsByLockRequest
+{
+    public List<string> UserIds { get; set; }
+
+    public string CurrencyCode { get; set; }
+}

--- a/TLabs.ExchangeSdk/Staking/UserStakesTotalsByLockDto.cs
+++ b/TLabs.ExchangeSdk/Staking/UserStakesTotalsByLockDto.cs
@@ -1,0 +1,12 @@
+namespace TLabs.ExchangeSdk.Staking;
+
+public class UserStakesTotalsByLockDto
+{
+    public decimal AnnualAmount { get; set; }
+
+    public decimal MonthlyAmount { get; set; }
+
+    public decimal OtherAmount { get; set; }
+
+    public bool HasAnnualStake => AnnualAmount > 0;
+}

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.867</Version>
+    <Version>1.0.868</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Добавил в SDK клиент для batch-стейков по lock period: `GetUsersStakesTotalsByLock` + DTO/request (версия 1.0.868). Считает только Active.

Заодно подчистил sold-каналы в BINI report DTO: вместо трёх одинаковых классов один `SoldChannelDto` (Flag / Amount / Counterparties).