### PR TITLE
Align manual verification contracts with SDK conventions

### DIFF
--- a/TLabs.ExchangeSdk/Verification/AdminVerificationUpdateDto.cs
+++ b/TLabs.ExchangeSdk/Verification/AdminVerificationUpdateDto.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace TLabs.ExchangeSdk.Verification;
+
+/// <summary>
+/// Complete editable KYC snapshot submitted by an administrator.
+/// Empty values intentionally clear the corresponding stored values.
+/// </summary>
+public class AdminVerificationUpdateDto
+{
+    public string Name { get; set; }
+    public string SecondName { get; set; }
+    public string MiddleName { get; set; }
+    public int? CitizenshipId { get; set; }
+    public DateTimeOffset? DateOfBirth { get; set; }
+    public string Phone { get; set; }
+    public string Skype { get; set; }
+    public int? CountryResidenceId { get; set; }
+    public string City { get; set; }
+    public string Address { get; set; }
+    public string PostCode { get; set; }
+    public string DocumentNumber { get; set; }
+    public DateTimeOffset? DocumentDateIssued { get; set; }
+    public DateTimeOffset? DocumentDateExpire { get; set; }
+    public string ProofOfAddress { get; set; }
+    public int? TypeProofOfAddressId { get; set; }
+    public int? TypeIdentityCardId { get; set; }
+    public string IdentityCard { get; set; }
+    public string IdentityCardBackside { get; set; }
+    public string PhotoWithDocument { get; set; }
+    public string UserAuthenticationVideo { get; set; }
+    public bool ApplicationFromExchanger { get; set; }
+}

--- a/TLabs.ExchangeSdk/Verification/VerificationDataSource.cs
+++ b/TLabs.ExchangeSdk/Verification/VerificationDataSource.cs
@@ -1,0 +1,8 @@
+namespace TLabs.ExchangeSdk.Verification;
+
+public enum VerificationDataSource
+{
+    OldFrontend = 10,
+    Admin = 20,
+    Sumsub = 30,
+}

--- a/TLabs.ExchangeSdk/Verification/VerificationUser.cs
+++ b/TLabs.ExchangeSdk/Verification/VerificationUser.cs
@@ -65,43 +65,6 @@ namespace TLabs.ExchangeSdk.Verification
         public VerificationDataSource DataSource { get; set; }
     }
 
-    /// <summary>
-    /// Complete editable KYC snapshot submitted by an administrator.
-    /// Empty values intentionally clear the corresponding stored values.
-    /// </summary>
-    public class AdminVerificationUpdateDto
-    {
-        public string Name { get; set; }
-        public string SecondName { get; set; }
-        public string MiddleName { get; set; }
-        public int? CitizenshipId { get; set; }
-        public DateTimeOffset? DateOfBirth { get; set; }
-        public string Phone { get; set; }
-        public string Skype { get; set; }
-        public int? CountryResidenceId { get; set; }
-        public string City { get; set; }
-        public string Address { get; set; }
-        public string PostCode { get; set; }
-        public string DocumentNumber { get; set; }
-        public DateTimeOffset? DocumentDateIssued { get; set; }
-        public DateTimeOffset? DocumentDateExpire { get; set; }
-        public string ProofOfAddress { get; set; }
-        public int? TypeProofOfAddressId { get; set; }
-        public int? TypeIdentityCardId { get; set; }
-        public string IdentityCard { get; set; }
-        public string IdentityCardBackside { get; set; }
-        public string PhotoWithDocument { get; set; }
-        public string UserAuthenticationVideo { get; set; }
-        public bool ApplicationFromExchanger { get; set; }
-    }
-
-    public enum VerificationDataSource
-    {
-        OldFrontend = 0,
-        Admin = 1,
-        Sumsub = 2
-    }
-
     public enum StatusVerificationUser
     {
         /// <summary>Not fully filled yet</summary>


### PR DESCRIPTION
## Summary
- move `AdminVerificationUpdateDto` into its own contract file
- move `VerificationDataSource` into its own enum file
- align enum values with SDK conventions: 10, 20, 30

## Test plan
- [x] Build `TLabs.ExchangeSdk`
- [x] Run verification tests: 49 passed, including PostgreSQL coverage
- [x] Run focused admin tests: 8 passed