### PR TITLE
Stop logging OTP codes in WithdrawalRequest.ToString

### DIFF
--- a/TLabs.ExchangeSdk.Tests/WithdrawalRequestTests.cs
+++ b/TLabs.ExchangeSdk.Tests/WithdrawalRequestTests.cs
@@ -1,0 +1,33 @@
+using NUnit.Framework;
+using TLabs.ExchangeSdk.Withdrawals;
+
+namespace TLabs.ExchangeSdk.Tests
+{
+    public class WithdrawalRequestTests
+    {
+        [Test]
+        public void ToString_DoesNotIncludeOtpCodes()
+        {
+            var request = new WithdrawalRequest
+            {
+                UserId = "user-1",
+                Amount = 10.5m,
+                CurrencyCode = "USDT",
+                Address = "TXYZ123",
+                EmailAuthCode = "123456",
+                AuthCode = "654321",
+            };
+
+            var text = request.ToString();
+
+            Assert.That(text, Does.Contain("user-1"));
+            Assert.That(text, Does.Contain("10.5"));
+            Assert.That(text, Does.Contain("USDT"));
+            Assert.That(text, Does.Contain("TXYZ123"));
+            Assert.That(text, Does.Not.Contain("emailAuthCode"));
+            Assert.That(text, Does.Not.Contain("gAuth"));
+            Assert.That(text, Does.Not.Contain("123456"));
+            Assert.That(text, Does.Not.Contain("654321"));
+        }
+    }
+}

--- a/TLabs.ExchangeSdk/Withdrawals/WithdrawalRequest.cs
+++ b/TLabs.ExchangeSdk/Withdrawals/WithdrawalRequest.cs
@@ -1,6 +1,4 @@
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 
 namespace TLabs.ExchangeSdk.Withdrawals
 {
@@ -44,7 +42,8 @@ namespace TLabs.ExchangeSdk.Withdrawals
         /// <summary>Only used in cash withdrawals</summary>
         public string PublicId { get; set; } = null;
 
+        // OTP fields (EmailAuthCode, AuthCode) must never appear in ToString — they are logged via {request}.
         public override string ToString() => $"{nameof(WithdrawalRequest)}({UserId}, {Amount} {CurrencyCode}, " +
-            $"to {Address}, emailAuthCode:{EmailAuthCode}, gAuth:{AuthCode} {(BankCard == null ? "" : $", {BankCard}")})";
+            $"to {Address}{(BankCard == null ? "" : $", {BankCard}")})";
     }
 }


### PR DESCRIPTION
## Summary
- Remove EmailAuthCode / AuthCode from WithdrawalRequest.ToString so withdrawal logs no longer leak email OTP or Google Authenticator codes.
- Add unit test covering that OTP values and field names are absent from ToString.

## Context
Grafana/Loki audit (2026-08-06): webapp logged WithdrawalRequest(... emailAuthCode:..., gAuth:...).

## Test plan
- [x] WithdrawalRequestTests.ToString_DoesNotIncludeOtpCodes (requires .NET 7 runtime locally)
- [ ] After publish, bump TLabs.ExchangeSdk in webapp/consumers and confirm withdrawal logs omit OTP fields

Made with [Cursor](https://cursor.com)