### PR TITLE
Add SDK contract for creating a user stake from admin balance

### DIFF
--- a/TLabs.ExchangeSdk/Staking/ClientStaking.cs
+++ b/TLabs.ExchangeSdk/Staking/ClientStaking.cs
@@ -38,6 +38,8 @@ namespace TLabs.ExchangeSdk.Staking
 
         Task<QueryResult> AdminCancelUserStake(Guid userStakeId);
 
+        Task<QueryResult<string>> CreateUserStakeByAdmin(CreateUserStakeByAdminDto dto);
+
         Task<StakingStatisticsDto> GetStakingStatistics(IReadOnlyCollection<string> userIds = null);
 
         Task<int> GetStakesCountForPeriod(DateTimeOffset fromDate, DateTimeOffset toDate,
@@ -159,6 +161,16 @@ namespace TLabs.ExchangeSdk.Staking
                 .InternalApi().PostJsonAsync(null).GetQueryResult();
             if (!result.Succeeded)
                 _logger.LogError($"AdminCancelUserStake failed for {userStakeId}: {result.ErrorsString}");
+            return result;
+        }
+
+        /// <summary>Create stake for user, funded by internal transfer from admin's balance</summary>
+        public virtual async Task<QueryResult<string>> CreateUserStakeByAdmin(CreateUserStakeByAdminDto dto)
+        {
+            var result = await $"brokerage/staking/admin/user-stakes/create-by-admin"
+                .InternalApi().PostJsonAsync<string>(dto).GetQueryResult();
+            if (!result.Succeeded)
+                _logger.LogError($"CreateUserStakeByAdmin failed: {result.ErrorsString} for {dto}");
             return result;
         }
 

--- a/TLabs.ExchangeSdk/Staking/CreateUserStakeByAdminDto.cs
+++ b/TLabs.ExchangeSdk/Staking/CreateUserStakeByAdminDto.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace TLabs.ExchangeSdk.Staking
+{
+    /// <summary>Create stake for user, funded by internal transfer from admin's balance</summary>
+    public class CreateUserStakeByAdminDto
+    {
+        /// <summary>Admin whose balance funds the stake</summary>
+        public string AdminUserId { get; set; }
+
+        /// <summary>User that receives the stake</summary>
+        public string UserId { get; set; }
+
+        public Guid StakingSettingId { get; set; }
+
+        public decimal Amount { get; set; }
+
+        public override string ToString() => $"{nameof(CreateUserStakeByAdminDto)}({Amount}, " +
+            $"admin:{AdminUserId} -> user:{UserId}, settingId:{StakingSettingId})";
+    }
+}

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.891</Version>
+    <Version>1.0.892</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- add `CreateUserStakeByAdminDto` (admin id, user id, staking setting id, amount)
- add `IClientStaking.CreateUserStakeByAdmin` calling
  `POST brokerage/staking/admin/user-stakes/create-by-admin`
- bump package version to 1.0.892

The endpoint itself lives in stock-brokerage (`StakingLockedService.CreateUserStakeByAdmin`):
it moves the amount from the admin balance to the user with an internal transfer and then
creates the stake. It returns the new stake id as `QueryResult<string>`, matching the
existing `CreateUserStake`.

Consumed by the new "Create stake by admin" page in stock-admin.

## Test plan
- [x] `dotnet build TLabs.ExchangeSdk -c Release` — 0 errors
- [x] end-to-end on an isolated stand: admin creates a stake for a user, both the transfer
      and the stake appear in the depository ledger
