### PR TITLE
Add idempotency key to CreateUserStakeByAdminDto

### DIFF
--- a/TLabs.ExchangeSdk/Staking/CreateUserStakeByAdminDto.cs
+++ b/TLabs.ExchangeSdk/Staking/CreateUserStakeByAdminDto.cs
@@ -15,7 +15,15 @@ namespace TLabs.ExchangeSdk.Staking
 
         public decimal Amount { get; set; }
 
+        /// <summary>
+        /// Idempotency key: caller keeps it unchanged while retrying the same operation
+        /// (lost response, timeout) and generates a new one for a different operation.
+        /// Brokerage uses it as the ledger ActionId and rejects a repeated request.
+        /// </summary>
+        public Guid RequestId { get; set; }
+
         public override string ToString() => $"{nameof(CreateUserStakeByAdminDto)}({Amount}, " +
-            $"admin:{AdminUserId} -> user:{UserId}, settingId:{StakingSettingId})";
+            $"admin:{AdminUserId} -> user:{UserId}, settingId:{StakingSettingId}, " +
+            $"requestId:{RequestId})";
     }
 }

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.892</Version>
+    <Version>1.0.893</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- add `Guid RequestId` to `CreateUserStakeByAdminDto`: an idempotency key supplied by the
  caller, used by brokerage as the ledger ActionId of the admin -> user transfer
- bump the package to 1.0.893

Follow-up to #328. The endpoint added there is not idempotent: a repeated
`create-by-admin` (retry after a lost response, operator pressing the button again) makes
a second transfer and a second stake. The key has to come from the caller — brokerage
cannot tell a retry from a legitimate second identical stake on its own.

Additive and source-compatible: no released consumer calls this endpoint yet, both
consumer PRs (ateregulov/stock-brokerage#96, ateregulov/stock-admin#312) are still open.

## Test plan
- [x] `dotnet test` — 8 passed