### PR TITLE
Add crypto deposits list/summary client contracts (1.0.894)

### DIFF
--- a/TLabs.ExchangeSdk/Depository/ClientDepository.cs
+++ b/TLabs.ExchangeSdk/Depository/ClientDepository.cs
@@ -304,5 +304,22 @@ namespace TLabs.ExchangeSdk.Depository
 
             return result;
         }
+
+        // Flurl WithTimeout = 60s (backstop). Admin page CTS = 45s (user-facing budget).
+        public virtual Task<PagedList<CryptoDepositListItemDto>> GetCryptoDeposits(
+            CryptoDepositsFilterDto filter, int page = 1, int pageSize = 25) =>
+            "depository/deposits/crypto/list".InternalApi()
+                .WithTimeout(TimeSpan.FromSeconds(60))
+                .SetQueryParam(nameof(page), page)
+                .SetQueryParam(nameof(pageSize), pageSize)
+                .PostJsonAsync(filter)
+                .ReceiveJson<PagedList<CryptoDepositListItemDto>>();
+
+        public virtual Task<CryptoDepositsSummaryDto> GetCryptoDepositsSummary(CryptoDepositsFilterDto filter) =>
+            "depository/deposits/crypto/summary".InternalApi()
+                .WithTimeout(TimeSpan.FromSeconds(60))
+                .PostJsonAsync(filter)
+                .ReceiveJson<CryptoDepositsSummaryDto>();
     }
 }
+

--- a/TLabs.ExchangeSdk/Depository/CryptoDepositListItemDto.cs
+++ b/TLabs.ExchangeSdk/Depository/CryptoDepositListItemDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace TLabs.ExchangeSdk.Depository
+{
+    public class CryptoDepositListItemDto
+    {
+        public Guid TransactionId { get; set; }
+        public DateTimeOffset Datetime { get; set; }
+        public decimal Amount { get; set; }
+        public string CurrencyCode { get; set; }
+        public string AdapterCode { get; set; }
+        public string UserId { get; set; }
+        public string TxId { get; set; }
+        public string ActionId { get; set; }
+    }
+}

--- a/TLabs.ExchangeSdk/Depository/CryptoDepositsFilterDto.cs
+++ b/TLabs.ExchangeSdk/Depository/CryptoDepositsFilterDto.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+namespace TLabs.ExchangeSdk.Depository
+{
+    public class CryptoDepositsFilterDto
+    {
+        /// <summary>Inclusive lower bound (required).</summary>
+        public DateTimeOffset From { get; set; }
+
+        /// <summary>Exclusive upper bound (required). Must be &gt; From.</summary>
+        public DateTimeOffset To { get; set; }
+
+        /// <summary>Null or empty = all currencies. Trim; drop blank entries before query.</summary>
+        public List<string> CurrencyCodes { get; set; }
+
+        /// <summary>Null or empty = all adapters. Trim; drop blank entries before query.</summary>
+        public List<string> AdapterCodes { get; set; }
+    }
+}

--- a/TLabs.ExchangeSdk/Depository/CryptoDepositsSummaryDto.cs
+++ b/TLabs.ExchangeSdk/Depository/CryptoDepositsSummaryDto.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace TLabs.ExchangeSdk.Depository
+{
+    public class CryptoDepositsSummaryDto
+    {
+        public List<CryptoDepositsSummaryRowDto> Rows { get; set; }
+
+        /// <summary>Sum of row Count values only. No cross-currency amount total.</summary>
+        public int TotalCount { get; set; }
+    }
+
+    public class CryptoDepositsSummaryRowDto
+    {
+        public string CurrencyCode { get; set; }
+        public string AdapterCode { get; set; }
+        public decimal Amount { get; set; }
+        public int Count { get; set; }
+    }
+}

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.892</Version>
+    <Version>1.0.894</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Add `ClientDepository.GetCryptoDeposits` / `GetCryptoDepositsSummary` calling `depository/deposits/crypto/list` and `.../summary`.
- Add DTOs for filter, list item, and currency×adapter summary (count total only; no cross-currency amount).
- Bump package version to **1.0.894** (needed for admin crypto deposits page; 1.0.893 on nuget.org does not include these APIs).

## Test plan
- [ ] Pack `TLabs.ExchangeSdk` 1.0.894 and publish to nuget.org
- [ ] Confirm nuget.org package contains `GetCryptoDeposits` / `GetCryptoDepositsSummary`
- [ ] Clean restore of a consumer (e.g. stock-admin) against nuget.org succeeds with PackageReference 1.0.894

## Note
Admin/depository PRs will follow after this package is published.

Made with [Cursor](https://cursor.com)