### PR TITLE
Drop unused stake-by-admin idempotency key

### DIFF
--- a/TLabs.ExchangeSdk/Staking/CreateUserStakeByAdminDto.cs
+++ b/TLabs.ExchangeSdk/Staking/CreateUserStakeByAdminDto.cs
@@ -15,15 +15,7 @@ namespace TLabs.ExchangeSdk.Staking
 
         public decimal Amount { get; set; }
 
-        /// <summary>
-        /// Idempotency key: caller keeps it unchanged while retrying the same operation
-        /// (lost response, timeout) and generates a new one for a different operation.
-        /// Brokerage uses it as the ledger ActionId and rejects a repeated request.
-        /// </summary>
-        public Guid RequestId { get; set; }
-
         public override string ToString() => $"{nameof(CreateUserStakeByAdminDto)}({Amount}, " +
-            $"admin:{AdminUserId} -> user:{UserId}, settingId:{StakingSettingId}, " +
-            $"requestId:{RequestId})";
+            $"admin:{AdminUserId} -> user:{UserId}, settingId:{StakingSettingId})";
     }
 }

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.894</Version>
+    <Version>1.0.895</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## What

Removes dead contract surface added with the create-stake-by-admin feature:

- `CreateUserStakeByAdminDto.RequestId` and its mention in `ToString()`
- version bump to 1.0.895

## Why

The idempotency key was introduced when brokerage moved the money itself and could
use the caller's key as the ledger `ActionId`. Brokerage now funds the stake through
the withdrawals pipeline, which builds the `ActionId` from its own withdrawal id, so
the field is never read; the admin panel stopped sending it in the same iteration.

## Impact

None on consumers: brokerage and admin are on 1.0.892, which predates `RequestId`.
They move to 1.0.895 in a follow-up once this is published.

## Testing

`dotnet build TLabs.ExchangeSdk` — 0 errors.