### PR TITLE
Add RiskReportUrl to AML screening DTOs (1.0.897)

### DIFF
--- a/TLabs.ExchangeSdk/Aml/AmlPendingDeposit.cs
+++ b/TLabs.ExchangeSdk/Aml/AmlPendingDeposit.cs
@@ -44,6 +44,9 @@ namespace TLabs.ExchangeSdk.Aml
         /// <summary>Raw provider response for the admin audit trail.</summary>
         public string ScreeningRaw { get; set; }
 
+        /// <summary>MistTrack risk report URL when the provider returned one.</summary>
+        public string RiskReportUrl { get; set; }
+
         public DateTimeOffset ScreenedAt { get; set; }
 
         /// <summary>When the deposit was received: the on-chain deposit time for backfill, or when it reached AML for live deposits.

--- a/TLabs.ExchangeSdk/Aml/AmlScreeningRecord.cs
+++ b/TLabs.ExchangeSdk/Aml/AmlScreeningRecord.cs
@@ -54,6 +54,9 @@ namespace TLabs.ExchangeSdk.Aml
         /// <summary>Raw provider JSON response (for the audit trail / admin drill-down).</summary>
         public string RawResponse { get; set; }
 
+        /// <summary>MistTrack risk report URL when the provider returned one.</summary>
+        public string RiskReportUrl { get; set; }
+
         /// <summary>True if the screening could not be performed (no key, network error, unsupported coin).</summary>
         public bool IsInconclusive { get; set; }
 

--- a/TLabs.ExchangeSdk/Aml/AmlScreeningResult.cs
+++ b/TLabs.ExchangeSdk/Aml/AmlScreeningResult.cs
@@ -16,6 +16,9 @@ namespace TLabs.ExchangeSdk.Aml
         /// <summary>Raw provider response kept for the admin audit trail.</summary>
         public string RawResponse { get; set; }
 
+        /// <summary>MistTrack risk report URL when the provider returned one.</summary>
+        public string RiskReportUrl { get; set; }
+
         /// <summary>True when the screening could not be performed (no key, network error, unsupported network).</summary>
         public bool IsInconclusive { get; set; }
 

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.895</Version>
+    <Version>1.0.897</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Add nullable `RiskReportUrl` to `AmlScreeningResult`, `AmlScreeningRecord`, and `AmlPendingDeposit`.
- Bump package version to **1.0.897** (do not overwrite published 1.0.896).

## Merge gate
Publish `TLabs.ExchangeSdk.1.0.897` to NuGet.org before merging consumer PRs (stock-withdrawals / stock-admin).

## Test plan
- [ ] Pack/restore 1.0.897 and confirm new properties serialize
- [ ] Consumer PRs build against published package

## Related
- Plan: `.cursor/workflow/misttrack-report-url/plan.md`