### PR TITLE
feat(futures): ClientFutures — фасадные ручки Stock.Futures (1.0.905)

### DIFF
--- a/TLabs.ExchangeSdk/Futures/ClientFutures.cs
+++ b/TLabs.ExchangeSdk/Futures/ClientFutures.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Threading.Tasks;
+using Flurl.Http;
+using Newtonsoft.Json.Linq;
+using TLabs.DotnetHelpers;
+
+namespace TLabs.ExchangeSdk.Futures;
+
+/// <summary>
+/// Ручки Stock.Futures через гейтвей — все роуты фьючерсов собраны здесь.
+/// Клиент прозрачного прокси: AllowAnyHttpStatus и сырой IFlurlResponse,
+/// чтобы фасад отдавал статус и тело ответа бэка как есть, без пересборки.
+/// </summary>
+public class ClientFutures
+{
+    public const string IdempotencyKeyHeader = "Idempotency-Key";
+
+    /// <summary>Свечи — публичная маркет-дата. query проксируется как есть</summary>
+    public Task<IFlurlResponse> GetCandles(string query) =>
+        Get($"futures/candles{query}");
+
+    /// <summary>Список торгуемых пар — публичная маркет-дата</summary>
+    public Task<IFlurlResponse> GetCurrencyPairs(string query) =>
+        Get($"futures/currency-pair{query}");
+
+    /// <summary>Цена и объём за сутки — публичная маркет-дата</summary>
+    public Task<IFlurlResponse> GetPriceAndVolume(string query) =>
+        Get($"futures/trade/price-and-volume{query}");
+
+    /// <summary>Счета пользователя. ensure=true заводит счёт по умолчанию, если счетов нет</summary>
+    public Task<IFlurlResponse> GetUserFuturesAccounts(string userId) =>
+        Get($"futures/account/user-futures-accounts/{WebUtility.UrlEncode(userId)}?ensure=true");
+
+    public Task<IFlurlResponse> UpdateFuturesAccount(JObject body) =>
+        "futures/account/internal/update-futures-account".InternalApi().AllowAnyHttpStatus().PutJsonAsync(body);
+
+    /// <summary>Перевод спот→фьючерсы. Ключ идемпотентности Stock.Futures читает из заголовка</summary>
+    public Task<IFlurlResponse> TransferFromSpot(JObject body, string idempotencyKey) =>
+        Post("futures/account/internal/transfer-from-spot", body, idempotencyKey);
+
+    /// <summary>Перевод фьючерсы→спот. Ключ идемпотентности Stock.Futures читает из заголовка</summary>
+    public Task<IFlurlResponse> TransferToSpot(JObject body, string idempotencyKey) =>
+        Post("futures/account/internal/transfer-to-spot", body, idempotencyKey);
+
+    public Task<IFlurlResponse> CreateOrder(JObject body) =>
+        "futures/order/create-internal".InternalApi().AllowAnyHttpStatus().PostJsonAsync(body);
+
+    public Task<IFlurlResponse> CloseOrder(JObject body) =>
+        "futures/order/close-internal".InternalApi().AllowAnyHttpStatus().PutJsonAsync(body);
+
+    public Task<IFlurlResponse> GetPositions(string query) =>
+        Get($"futures/order/positions-internal{query}");
+
+    public Task<IFlurlResponse> GetPositionSummary(string query) =>
+        Get($"futures/order/position-summary-internal{query}");
+
+    public Task<IFlurlResponse> GetOrdersHistory(JObject body) =>
+        "futures/order/orders-history-internal".InternalApi().AllowAnyHttpStatus().PostJsonAsync(body);
+
+    private static Task<IFlurlResponse> Get(string url) =>
+        url.InternalApi().AllowAnyHttpStatus().GetAsync();
+
+    private static Task<IFlurlResponse> Post(string url, JObject body, string idempotencyKey)
+    {
+        var request = url.InternalApi().AllowAnyHttpStatus();
+        if (idempotencyKey.HasValue())
+            request = request.WithHeader(IdempotencyKeyHeader, idempotencyKey);
+        return request.PostJsonAsync(body);
+    }
+}

--- a/TLabs.ExchangeSdk/ServiceCollectionExtensions.cs
+++ b/TLabs.ExchangeSdk/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ namespace TLabs.ExchangeSdk
             services.AddTransient<Deposits.ClientDeposits>();
             services.AddTransient<ExternalPayments.ClientExternalPayments>();
             services.AddTransient<Exchanges.ClientExchanges>();
+            services.AddTransient<Futures.ClientFutures>();
             services.AddTransient<Helpdesk.ClientHelpdesk>();
             services.AddTransient<LiquidityImport.ClientLiquidityConnectors>();
             services.AddTransient<LiquidityImport.ClientLiquidityMain>();

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.904</Version>
+    <Version>1.0.905</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Перенос `ClientFutures` из webapp (`WebAppClasses/Services/HttpFactoryClients/ClientFutures.cs`) в SDK — по замечаниям ревью в ateregulov/stock-n10-webapp#204 и #203.

Клиент прозрачного прокси для фасада фьючерсов:
- `AllowAnyHttpStatus()` + сырой `IFlurlResponse` — фасад отдаёт статус и тело ответа Stock.Futures как есть (бэк различает 400/403/404/409 с телом `{ code: ... }`);
- переводы спот↔фьючерсы пробрасывают `Idempotency-Key` заголовком — по образцу `ClientPaymentCards.CreateTransfer`;
- регистрация в `AddSdkServices`, Transient, как у остальных клиентов.

Чисто аддитивно, существующий код не тронут.

После мержа и публикации 1.0.905 на nuget.org: в webapp готова ветка `refactor/futures-client-sdk` (удаляет локальную копию, −73 строки) — мержить её после ateregulov/stock-n10-webapp#203, #204 и #205.