### PR TITLE
add Solana adapter (sol) address validation and solscan (1.0.906)

### DIFF
--- a/TLabs.ExchangeSdk.Tests/CryptoAddressesHelperTests.cs
+++ b/TLabs.ExchangeSdk.Tests/CryptoAddressesHelperTests.cs
@@ -1,0 +1,118 @@
+using NUnit.Framework;
+using TLabs.ExchangeSdk.CryptoAdapters;
+using TLabs.ExchangeSdk.Currencies;
+
+namespace TLabs.ExchangeSdk.Tests
+{
+    public class CryptoAddressesHelperTests
+    {
+        // 32 zero bytes — Bitcoin/Solana Base58 leading '1' is a 0x00 pad.
+        private const string SystemProgram = "11111111111111111111111111111111";
+        // Canonical Tokenkeg program id (32-byte pubkey, 44-char base58).
+        private const string Tokenkeg = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+        private const string MainnetUsdc = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+        private const string MainnetUsdt = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+        private const string DevnetUsdc = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        // Typical on-curve wallet pubkeys (32-byte decode).
+        private const string TypicalWalletA = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+        private const string TypicalWalletB = "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU";
+
+        [Test]
+        public void Sol_Known32BytePubkey_IsValid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", Tokenkeg), Is.True);
+        }
+
+        [Test]
+        public void Sol_PubkeyStartingWith1_IsValid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", SystemProgram), Is.True);
+        }
+
+        [TestCase(MainnetUsdc)]
+        [TestCase(MainnetUsdt)]
+        [TestCase(DevnetUsdc)]
+        [TestCase(TypicalWalletA)]
+        [TestCase(TypicalWalletB)]
+        public void Sol_TypicalAddresses_AreValid(string address)
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", address), Is.True);
+        }
+
+        [Test]
+        public void Sol_32CharBase58ThatDecodesToWrongLength_IsInvalid()
+        {
+            var tooFewBytes = new string('2', 32);
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", tooFewBytes), Is.False);
+        }
+
+        [Test]
+        public void Sol_44CharBase58ThatDecodesToWrongLength_IsInvalid()
+        {
+            var tooManyBytes = new string('z', 44);
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", tooManyBytes), Is.False);
+        }
+
+        [Test]
+        public void Sol_ShorterThan32Chars_IsInvalid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", new string('1', 31)), Is.False);
+        }
+
+        [Test]
+        public void Sol_LongerThan44Chars_IsInvalid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", Tokenkeg + "1"), Is.False);
+        }
+
+        [TestCase("0")]
+        [TestCase("O")]
+        [TestCase("I")]
+        [TestCase("l")]
+        public void Sol_AmbiguousBase58Chars_AreInvalid(string badChar)
+        {
+            // Bitcoin/Solana Base58 alphabet omits 0, O, I, l. Regex must reject them
+            // before decode (they would also fail IndexOf).
+            string mutated = badChar + Tokenkeg.Substring(1);
+            Assert.That(mutated.Length, Is.EqualTo(Tokenkeg.Length));
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", mutated), Is.False);
+        }
+
+        [Test]
+        public void Sol_TonAddress_IsInvalid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol",
+                "UQBhG8VrdcOYZW77pbFv9NnzLIBnrwYRWAtiIQu2nhb2BoS5"), Is.False);
+        }
+
+        [Test]
+        public void Sol_EthAddress_IsInvalid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol",
+                "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0"), Is.False);
+        }
+
+        [Test]
+        public void Sol_Empty_IsInvalid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", ""), Is.False);
+            Assert.That(CryptoAddressesHelper.IsValidAddress("sol", null), Is.False);
+        }
+
+        [Test]
+        public void WrongAdapter_SolAddress_IsInvalid()
+        {
+            Assert.That(CryptoAddressesHelper.IsValidAddress("ton", Tokenkeg), Is.False);
+            Assert.That(CryptoAddressesHelper.IsValidAddress("eth", Tokenkeg), Is.False);
+        }
+
+        [Test]
+        public void AdapterSol_IsRegistered()
+        {
+            Assert.That(Adapter.AdapterSol.Code, Is.EqualTo("sol"));
+            Assert.That(Adapter.AdapterSol.Name, Is.EqualTo("Solana"));
+            Assert.That(Adapter.AdapterSol.MainCurrencyCode, Is.EqualTo("SOL"));
+            Assert.That(Adapter.DefaultAdapters, Does.Contain(Adapter.AdapterSol));
+        }
+    }
+}

--- a/TLabs.ExchangeSdk.Tests/CurrencyExplorerTests.cs
+++ b/TLabs.ExchangeSdk.Tests/CurrencyExplorerTests.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+using TLabs.ExchangeSdk.Currencies;
+
+namespace TLabs.ExchangeSdk.Tests
+{
+    public class CurrencyExplorerTests
+    {
+        private const string Sig = "5wJbGqE9YqKqYqKqYqKqYqKqYqKqYqKqYqKqYqKqYqKq";
+
+        [Test]
+        public void GetTxUrl_Sol_RawSignature()
+        {
+            Assert.That(CurrencyExplorer.GetTxUrl("sol", Sig),
+                Is.EqualTo($"https://solscan.io/tx/{Sig}"));
+        }
+
+        [Test]
+        public void GetTxUrl_Sol_PlatformDepositTxId_StripsCurrencySuffix()
+        {
+            Assert.That(CurrencyExplorer.GetTxUrl("sol", Sig + ":USDC"),
+                Is.EqualTo(CurrencyExplorer.GetTxUrl("sol", Sig)));
+        }
+
+        [Test]
+        public void GetTxUrl_Sol_UsdtAndSolSuffixes_StripToSameUrl()
+        {
+            string raw = CurrencyExplorer.GetTxUrl("sol", Sig);
+            Assert.That(CurrencyExplorer.GetTxUrl("sol", Sig + ":USDT"), Is.EqualTo(raw));
+            Assert.That(CurrencyExplorer.GetTxUrl("sol", Sig + ":SOL"), Is.EqualTo(raw));
+        }
+
+        [Test]
+        public void GetTxUrl_Sol_WithdrawalIdHasNoSuffix()
+        {
+            string url = CurrencyExplorer.GetTxUrl("sol", Sig);
+            Assert.That(url, Is.EqualTo($"https://solscan.io/tx/{Sig}"));
+            Assert.That(url, Does.Not.Contain(":SOL"));
+            Assert.That(url, Does.Not.Contain(":USDC"));
+            Assert.That(url, Does.Not.Contain(":USDT"));
+        }
+
+        [Test]
+        public void GetAddressUrl_Sol()
+        {
+            const string wallet = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
+            Assert.That(CurrencyExplorer.GetAddressUrl("sol", wallet),
+                Is.EqualTo($"https://solscan.io/account/{wallet}"));
+        }
+    }
+}

--- a/TLabs.ExchangeSdk/CryptoAdapters/CryptoAddressesHelper.cs
+++ b/TLabs.ExchangeSdk/CryptoAdapters/CryptoAddressesHelper.cs
@@ -1,9 +1,14 @@
+using System;
+using System.Numerics;
 using System.Text.RegularExpressions;
 
 namespace TLabs.ExchangeSdk.CryptoAdapters
 {
     public static class CryptoAddressesHelper
     {
+        private static readonly Regex SolanaAddressRegex = new("^[1-9A-HJ-NP-Za-km-z]{32,44}$", RegexOptions.Compiled);
+        private const string BitcoinBase58Alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
         public static bool IsValidAddress(string adapterCode, string adapterAddress) => adapterCode switch
         {
             // btc-like
@@ -23,11 +28,45 @@ namespace TLabs.ExchangeSdk.CryptoAdapters
 
             // other
             "ton" => new Regex("^[A-Za-z0-9\\-_]{48}$").IsMatch(adapterAddress),
+            "sol" => IsValidSolanaAddress(adapterAddress),
             "del" => new Regex("^dx1[ac-hj-np-z0-9]{38}$").IsMatch(adapterAddress),
             "pzm" => new Regex("^PRIZM-[A-Z2-9]{4}-[A-Z2-9]{4}-[A-Z2-9]{4}-[A-Z2-9]{5}$").IsMatch(adapterAddress),
             "umi" => new Regex("^umi1[ac-np-z0-9]{58}$").IsMatch(adapterAddress),
             "tstc" => true,
             _ => false
         };
+
+        /// <summary>
+        /// Solana addresses are 32-byte Ed25519 public keys encoded with Bitcoin/Solana Base58
+        /// (not Base58Check). A leading alphabet '1' is a 0x00 pad byte.
+        /// </summary>
+        private static bool IsValidSolanaAddress(string adapterAddress)
+        {
+            if (adapterAddress == null || !SolanaAddressRegex.IsMatch(adapterAddress))
+                return false;
+            return TryDecodeBase58ToExactly32Bytes(adapterAddress);
+        }
+
+        private static bool TryDecodeBase58ToExactly32Bytes(string input)
+        {
+            int leadingZeros = 0;
+            while (leadingZeros < input.Length && input[leadingZeros] == '1')
+                leadingZeros++;
+
+            BigInteger value = BigInteger.Zero;
+            for (int i = leadingZeros; i < input.Length; i++)
+            {
+                int digit = BitcoinBase58Alphabet.IndexOf(input[i]);
+                if (digit < 0)
+                    return false;
+                value = value * 58 + digit;
+            }
+
+            byte[] payload = value.IsZero
+                ? Array.Empty<byte>()
+                : value.ToByteArray(isUnsigned: true, isBigEndian: true);
+
+            return leadingZeros + payload.Length == 32;
+        }
     }
 }

--- a/TLabs.ExchangeSdk/Currencies/Adapter.cs
+++ b/TLabs.ExchangeSdk/Currencies/Adapter.cs
@@ -35,6 +35,7 @@ namespace TLabs.ExchangeSdk.Currencies
 
         // other
         public static Adapter AdapterTon = new() { Code = "ton", Name = "TON", MainCurrencyCode = "GRAM", };
+        public static Adapter AdapterSol = new() { Code = "sol", Name = "Solana", MainCurrencyCode = "SOL", };
         public static Adapter AdapterDel = new() { Code = "del", Name = "Decimal", MainCurrencyCode = "DEL", };
         public static Adapter AdapterPzm = new() { Code = "pzm", Name = "Prizm", MainCurrencyCode = "PZM", };
         public static Adapter AdapterUmi = new() { Code = "umi", Name = "Umi", MainCurrencyCode = "UMI", };
@@ -43,7 +44,7 @@ namespace TLabs.ExchangeSdk.Currencies
         public static List<Adapter> DefaultAdapters = new()
         {
             AdapterBtc, AdapterDash, AdapterDoge, AdapterLtc,
-            AdapterEth, AdapterBsc, AdapterBini, AdapterTrx, AdapterOrgon, AdapterTon, AdapterDel, AdapterPzm, AdapterUmi, AdapterAdvcash,
+            AdapterEth, AdapterBsc, AdapterBini, AdapterTrx, AdapterOrgon, AdapterTon, AdapterSol, AdapterDel, AdapterPzm, AdapterUmi, AdapterAdvcash,
         };
 
         public override string ToString() =>

--- a/TLabs.ExchangeSdk/Currencies/CurrencyExplorer.cs
+++ b/TLabs.ExchangeSdk/Currencies/CurrencyExplorer.cs
@@ -43,12 +43,19 @@ public class CurrencyExplorer
     static readonly CurrencyExplorer DEL = new CurrencyExplorer("del", "https://explorer.decimalchain.com/transactions/", "https://explorer.decimalchain.com/address/");
     static readonly CurrencyExplorer UMI = new CurrencyExplorer("umi", "https://blockchain.umi.top/transaction/", "https://blockchain.umi.top/address/");
     static readonly CurrencyExplorer TON = new CurrencyExplorer("ton", "https://tonscan.org/tx/", "https://tonscan.org/address/");
+    static readonly CurrencyExplorer SOL = new CurrencyExplorer("sol", "https://solscan.io/tx/", "https://solscan.io/account/");
 
     public static readonly List<CurrencyExplorer> CurrencyExplorers = new List<CurrencyExplorer>()
-            { BTC, LTC, DASH, DOGE, COLX, SIN, PZM, ETH, BNB, BINI, TRX, DEL, UMI, ORGON, TON };
+            { BTC, LTC, DASH, DOGE, COLX, SIN, PZM, ETH, BNB, BINI, TRX, DEL, UMI, ORGON, TON, SOL };
 
     public static string GetTxUrl(string adapterCode, string txId)
     {
+        if (adapterCode == "sol" && txId != null)
+        {
+            int colon = txId.LastIndexOf(':');
+            if (colon >= 0)
+                txId = txId.Substring(0, colon);
+        }
         CurrencyExplorer explorer = CurrencyExplorers.FirstOrDefault(c => c.AdapterCode == adapterCode);
         string result = explorer != null ? $"{explorer.TransactionUrl}{txId}" : null;
         return result;

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.905</Version>
+    <Version>1.0.906</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary
- Register adapter `sol` (main currency SOL) in `Adapter.DefaultAdapters`.
- Validate Solana addresses as Base58 that decodes to exactly 32 bytes (reject 0/O/I/l and wrong length).
- Add Solscan explorer URLs; strip `{signature}:{currency}` suffix on tx links so deposits still open the raw signature.

## Test plan
- [x] `dotnet test` filter CryptoAddressesHelperTests + CurrencyExplorerTests — 25/25 pass
- [ ] After merge, publish **1.0.906** to nuget.org (do not pack locally for consumers)
- [ ] Then bump `stock-adapter-solana` PackageReference from 1.0.902 to 1.0.906
