### PR TITLE
feat(futures): ClientFutures — сделки, история переводов, статус перевода (1.0.907)

### DIFF
--- a/TLabs.ExchangeSdk/Futures/ClientFutures.cs
+++ b/TLabs.ExchangeSdk/Futures/ClientFutures.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Threading.Tasks;
 using Flurl.Http;
@@ -27,6 +28,10 @@ public class ClientFutures
     public Task<IFlurlResponse> GetPriceAndVolume(string query) =>
         Get($"futures/trade/price-and-volume{query}");
 
+    /// <summary>Сделки пользователя. userId обязателен в query</summary>
+    public Task<IFlurlResponse> GetUserTrades(string query) =>
+        Get($"futures/trade/user-internal{query}");
+
     /// <summary>Счета пользователя. ensure=true заводит счёт по умолчанию, если счетов нет</summary>
     public Task<IFlurlResponse> GetUserFuturesAccounts(string userId) =>
         Get($"futures/account/user-futures-accounts/{WebUtility.UrlEncode(userId)}?ensure=true");
@@ -41,6 +46,14 @@ public class ClientFutures
     /// <summary>Перевод фьючерсы→спот. Ключ идемпотентности Stock.Futures читает из заголовка</summary>
     public Task<IFlurlResponse> TransferToSpot(JObject body, string idempotencyKey) =>
         Post("futures/account/internal/transfer-to-spot", body, idempotencyKey);
+
+    /// <summary>Статус перевода: state перечитывается до Completed/Failed. userId обязателен в query</summary>
+    public Task<IFlurlResponse> GetTransferStatus(Guid transferId, string query) =>
+        Get($"futures/account/internal/futures-transfers/{transferId}{query}");
+
+    /// <summary>История переводов между спотом и фьючерсными счетами. userId обязателен в query</summary>
+    public Task<IFlurlResponse> GetTransactionHistory(string query) =>
+        Get($"futures/transaction-history/internal{query}");
 
     public Task<IFlurlResponse> CreateOrder(JObject body) =>
         "futures/order/create-internal".InternalApi().AllowAnyHttpStatus().PostJsonAsync(body);

--- a/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
+++ b/TLabs.ExchangeSdk/TLabs.ExchangeSdk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
-    <Version>1.0.906</Version>
+    <Version>1.0.907</Version>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Три недостающих метода для фасадных ручек webapp (PR ateregulov/stock-n10-webapp#203):

- `GetUserTrades(query)` → `futures/trade/user-internal`
- `GetTransactionHistory(query)` → `futures/transaction-history/internal`
- `GetTransferStatus(transferId, query)` → `futures/account/internal/futures-transfers/{transferId}` — internal-вариант добавлен в T-Labs/stock-marginal-trading#5

Версия 1.0.907. После мержа нужна публикация — webapp в #203 уже ссылается на 1.0.907.
